### PR TITLE
Remove references to deprecated help.exercism.io site

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -1,4 +1,4 @@
-Refer to the [Exercism help page](http://help.exercism.io/getting-started-with-coffeescript.html) for getting started with CoffeeScript.
+Refer to the [Exercism CoffeScript page](http://exercism.io/languages/coffeescript) for getting started with CoffeeScript.
 
 In order to run the test, you can run the test file from the exercise directory. For example, if the test suite is called hello_world.spec.coffee, you can run the following command:
     jasmine-node --coffee hello_world.spec.coffee

--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -18,11 +18,11 @@ If you have a paid version of Visual Studio, you can download a Visual Studio so
 
 1. Download the [Exercism.io Visual Studio Template](https://github.com/rprouse/Exercism.VisualStudio) from GitHub by clicking the Download Zip button on the page.
 2. Unzip the template into your exercises directory, for example `C:\src\exercises`
-2. Install the [Exercism CLI](http://help.exercism.io/installing-the-cli.html)
+2. Install the [Exercism CLI](http://exercism.io/cli)
 3. Open a command prompt to your exercise directory
 4. Add your API key to exercism `exercism configure --key=YOUR_API_KEY`
 5. Configure your source directory in exercism `exercism configure --dir=C:\src\exercises`
-6. [Fetch your first exercise](http://help.exercism.io/fetching-exercises.html) `exercism fetch coffeescript`
+6. [Fetch your first exercise](http://exercism.io/languages/coffeescript) `exercism fetch coffeescript`
 7. Open the Exercism solution in Visual Studio
 8. Expand the Exercism.coffeescript project
 9. Click on **Show All Files** in Solution Explorer (See below)


### PR DESCRIPTION
Closes #56.