### PR TITLE
Fixes test names

### DIFF
--- a/exercises/luhn/luhn_test.spec.coffee
+++ b/exercises/luhn/luhn_test.spec.coffee
@@ -26,11 +26,11 @@ describe 'Luhn', ->
     luhn = new Luhn(201773)
     expect(luhn.checksum).toEqual(21)
 
-  xit "valid number", ->
+  xit "invalid number", ->
     luhn = new Luhn(738)
     expect(luhn.valid).toEqual(false)
 
-  xit "invalid number", ->
+  xit "valid number", ->
     luhn = new Luhn(8739567)
     expect(luhn.valid).toEqual(true)
 


### PR DESCRIPTION
The spec "valid number" checked for `luhn.valid` to be `false`, and vice versa. The tests match the description of the algorithm, I just flipped the spec.